### PR TITLE
fix(sort): sorting list of abbreviations and acronyms

### DIFF
--- a/latexmkrc
+++ b/latexmkrc
@@ -4,7 +4,7 @@
 # LaTeX através do latexmk e utilizando a classe pucrs-ppgcc.cls.
 #
 # por Ricardo Piccoli <rfbpiccoli at gmail dot com>.
-@default_files = ( "exemplo" );
+@default_files = ( "_a-principal-ex" );
 
 push @generated_exts, "loa";
 push @generated_exts, "lob";

--- a/sort.sh
+++ b/sort.sh
@@ -29,7 +29,7 @@ function abort() {
    exit 1
 }
 
-readonly FILE="$1"
+readonly FILE="$(basename $1 .tex)"
 readonly CLS="pucrs-ppgcc.cls"
 
 if [[ $# -lt 1 ]]; then


### PR DESCRIPTION
### Steps to reproduce
- clone the repository
- run `make`
- open the PDF

### Current behavior
The build will fail because the `exemplo` file doesn't exist (I've included a fix for that too). After fixing the bug and opening the PDF, you will see that the lists of abbreviations and acronyms are not sorted.

### Expected behavior
Lists of abbreviations and acronyms are sorted.

### Fix
Remove the file extension (`.tex`) from the first parameter in `sort.sh`.